### PR TITLE
Python 3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ tool](http://www.secdev.org/projects/scapy/) to allow capturing packets via
 Installation
 --------------------
 
-It's a regular package for Python 2.7 (not 3.X).
+It's a regular package for Python 3
 
 Using [pip](http://pip-installer.org/) is the best way:
 
@@ -40,7 +40,7 @@ Current-git version can be installed like this:
 
 ### Requirements
 
-* Python 2.7 with ctypes support
+* Python 3
 * [scapy](http://www.secdev.org/projects/scapy/)
 * [CFFI](http://cffi.readthedocs.org) (for libnetfilter_log bindings)
 * [libnetfilter_log](http://netfilter.org/projects/libnetfilter_log)
@@ -60,6 +60,7 @@ installed as default L2 listener like this:
 
 	>>> import scapy_nflog
 	>>> scapy_nflog.install_nflog_listener()
+	>>> sniff(prn=handler)
 
 install_nflog_listener above is a one-line function, doing `conf.L2listen =
 NFLOGListenSocket`, so if you're building custom module on scapy,

--- a/scapy_nflog.py
+++ b/scapy_nflog.py
@@ -20,7 +20,7 @@ class NFLOGReaderThread(Thread):
 		super(NFLOGReaderThread, self).__init__()
 		self.queues, self.nflog_kwargs, self.pipe = queues, nflog_kwargs, deque()
 		self.pipe_chk, self._pipe = os.pipe()
-		self.pipe_chk, self._pipe = os.fdopen(self.pipe_chk, 'r', 0), os.fdopen(self._pipe, 'w', 0)
+		self.pipe_chk, self._pipe = os.fdopen(self.pipe_chk, 'r'), os.fdopen(self._pipe, 'w')
 
 	def run(self):
 		nflog = NFLOG().generator(self.queues, extra_attrs=['ts'], **self.nflog_kwargs)
@@ -45,7 +45,7 @@ class NFLOGListenSocket(SuperSocket):
 		self.nflog.start()
 		self.ins = self.nflog.pipe_chk
 
-	def recv(self, bufsize):
+	def recv(self):
 		self.ins.read(1) # used only for poll/sync
 		pkt, ts = self.nflog.pipe.popleft()
 		if pkt is None: return

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from nflog_cffi import NFLOG
 setup(
 
 	name = 'scapy-nflog-capture',
-	version = '13.05.0',
+	version = '13.06.0',
 	author = 'Mike Kazantsev',
 	author_email = 'mk.fraggod@gmail.com',
 	license = 'WTFPL',
@@ -36,8 +36,8 @@ setup(
 		'License :: OSI Approved',
 		'Operating System :: POSIX :: Linux',
 		'Programming Language :: Python',
-		'Programming Language :: Python :: 2.7',
-		'Programming Language :: Python :: 2 :: Only',
+		'Programming Language :: Python :: 3',
+		'Programming Language :: Python :: 3 :: Only',
 		'Topic :: Security',
 		'Topic :: System :: Networking :: Monitoring',
 		'Topic :: System :: Operating System Kernels :: Linux' ],


### PR DESCRIPTION
If we try to use the current version of scapy_nflog plugin we get this error:

Traceback (most recent call last):
  File "/home/kix/src/scapy_parser/scapy_parser_reply.py", line 548, in <module>
    sniff(prn=handler, store=0)
  File "/usr/local/lib/python3.10/dist-packages/scapy/sendrecv.py", line 1263, in sniff
    sniffer._run(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/scapy/sendrecv.py", line 1127, in _run
    sniff_sockets[L2socket(type=ETH_P_ALL, iface=iface,
  File "/usr/local/lib/python3.10/dist-packages/scapy_nflog.py", line 44, in __init__
    self.nflog = NFLOGReaderThread(queues, **nflog_kwargs)
  File "/usr/local/lib/python3.10/dist-packages/scapy_nflog.py", line 23, in __init__
    self.pipe_chk, self._pipe = os.fdopen(self.pipe_chk, 'r', 0), os.fdopen(self._pipe, 'w', 0)
  File "/usr/lib/python3.10/os.py", line 1029, in fdopen
    return io.open(fd, mode, buffering, encoding, *args, **kwargs)
ValueError: can't have unbuffered text I/O

With the changes included in the patch, is possible to use scapy_nflog with Python 3.